### PR TITLE
Added config option to allow for setting additional request headers

### DIFF
--- a/src/main/webapp/js/ImageUploader.js
+++ b/src/main/webapp/js/ImageUploader.js
@@ -88,6 +88,7 @@ ImageUploader.prototype.performUpload = function(imageData, completionCallback) 
     var xhr = new XMLHttpRequest();
     var This = this;
     var uploadInProgress = true;
+    var headers = this.config.requestHeaders;
     xhr.onload = function(e) {
         uploadInProgress = false;
         This.uploadComplete(e, completionCallback);
@@ -96,6 +97,19 @@ ImageUploader.prototype.performUpload = function(imageData, completionCallback) 
         This.progressUpdate(e.loaded, e.total);
     }, false);
     xhr.open('POST', this.config.uploadUrl, true);
+    
+    if(typeof headers === 'object' && headers !== null) {
+        Object.keys(headers).forEach(function(key,index) {
+            if(typeof headers[key] !== 'string') {
+                var headersArray = headers[key];
+                for(var i = 0, j = headersArray.length; i < j; i++) {
+                    xhr.setRequestHeader(key, headersArray[i]);
+                }   
+            } else {
+                xhr.setRequestHeader(key, headers[key]);                
+            }
+        });
+    }
     
     xhr.send(imageData.split(',')[1]);
 


### PR DESCRIPTION
I added some code that allows the user to set for some additional request headers that might be required by the server in order to process the request, such as API/Auth tokens.

Usage:
`'requestHeaders': object`

Example:

``` javascript
var uploader = new ImageUploader({
    inputElement: document.getElementById('newOrderImage'),
    uploadUrl: 'view-vehicle-status.php',
    maxWidth: 1024,
    quality: 0.90,
    requestHeaders: {
        'Sample-Header': '9001',
        Token: 'GDSFH-AJHF-KALJ-SDFH',
        'Multi-Value-Header': ['sth', 32, true]
    }
});
```
