### PR TITLE
[fix] correct output of <div> tag word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ These properties are used as conditions when the image should be scaled down pro
 - **timeout** - A number in milliseconds specifying the maximum time to wait for file uploads to finish, after which they will be aborted.
 
 #### Debug properties ####
-- **debug** - A boolean flag to show the images in a <div> on the containing page before upload. Default value: false.
-- **workspace** - An element within which images are appended before upload (when **debug** is set to true). If not specified, then a new <div> tag will be appended to the end of HTML body where the images will be rendered.
+- **debug** - A boolean flag to show the images in a `<div>` on the containing page before upload. Default value: false.
+- **workspace** - An element within which images are appended before upload (when **debug** is set to true). If not specified, then a new `<div>` tag will be appended to the end of HTML body where the images will be rendered.
 
 #### Callback properties ####
 - **onScale** - A function which is invoked when final image is generated right before the upload starts. 1 argument passed: image data in data URL format. This callback function is useful for displaying a thumbnail (preview) of the selected image with correct orientation (the autoRotate option should be set to true).


### PR DESCRIPTION
There was a typo, so the word `<div>` became hidden in README file. Now it's visible again.