### PR TITLE
[fix] IE function default value error

### DIFF
--- a/src/main/webapp/js/ImageUploader.js
+++ b/src/main/webapp/js/ImageUploader.js
@@ -113,7 +113,7 @@ ImageUploader.prototype.drawImage = function(context, img, x, y, width, height, 
 	context.restore();
 }
 
-ImageUploader.prototype.scaleImage = function(img, completionCallback, orientation = 1) {
+ImageUploader.prototype.scaleImage = function(img, completionCallback, orientation) {
     var canvas = document.createElement('canvas');
 	canvas.width = img.width;
 	canvas.height = img.height;
@@ -125,6 +125,8 @@ ImageUploader.prototype.scaleImage = function(img, completionCallback, orientati
 	var styleWidth  = canvas.style.width;
     var height = canvas.height;
 	var styleHeight = canvas.style.height;
+	if (typeof orientation === 'undefined')
+        orientation = 1;
     if (orientation) {
 		if (orientation > 4) {
 			canvas.width  = height;


### PR DESCRIPTION
The problem is that the default parameter for JS functions is an experimental feature. While this code was working good in Chrome and Firefox, it didn't work at all in IE. When IE faced the default parameter, then it invalidated the whole ImageUploader code, as a result it lead to error "ImageUploader not found". Now this code is fixed and uses only the standard JS syntax and it works in IE now.