### PR TITLE
[fix] correct scaling

### DIFF
--- a/src/main/webapp/js/ImageUploader.js
+++ b/src/main/webapp/js/ImageUploader.js
@@ -77,6 +77,10 @@ ImageUploader.prototype.handleFileSelection = function(file, completionCallback)
 					This.scaleImage(img, completionCallback);
 				}
 			}
+			else{
+			    //No rotation, just scale the image
+                This.scaleImage(img, completionCallback);
+            }
         }
     };
     reader.readAsDataURL(file);
@@ -172,8 +176,8 @@ ImageUploader.prototype.scaleImage = function(img, completionCallback, orientati
 	//Let's find the max available width for scaled image
 	var ratio = canvas.width/canvas.height;
 	var mWidth = Math.min(this.config.maxWidth, ratio*this.config.maxHeight);
-	if ( (this.config.maxSize>0) && (this.config.maxSize<canvas.width*canvas.height/1000) )
-		mWidth = Math.min(mWidth, Math.floor(Math.sqrt(this.config.maxSize*ratio)));
+	if ( (this.config.maxSize>0) && (this.config.maxSize<canvas.width*canvas.height/1000000) )
+		mWidth = Math.min(mWidth, Math.floor(Math.sqrt(this.config.maxSize*ratio)*1000));
 	if ( !!this.config.scaleRatio )
 		mWidth = Math.min(mWidth, Math.floor(this.config.scaleRatio*canvas.width));
 	


### PR DESCRIPTION
Fixes #13
I added code to fix all the problems from there, except the last line about exporting in function `toDataURL` to formats other than `jpeg`. There are 2 reasons for that:

- it's not a bug, but a feature
- not all browsers may support export to formats other than `jpeg` and `png`. For example, Chrome even supports `webp`, see the [docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL).
- the user (programmer) may not want to have an image in the original format. Usually when we upload an image we want to have it in a predefined format, usually `jpeg`. It does not matter what kind of image the user selects: it may be any format supported by the browser, but after uploading we will have always `jpeg`, i.e. auto conversion is performed. I think it's logical. Alternatively, we could add a new option that would define the output format in which the JS code saves the final image. But such option is beyond the current PR.
